### PR TITLE
Move[#94]:  Generate Content steps in Github action to separated shell script

### DIFF
--- a/.github/workflows/generate-content.yml
+++ b/.github/workflows/generate-content.yml
@@ -28,41 +28,7 @@ jobs:
       run: sudo apt-get install jq -y
 
     - name: Generate Content
-      run: |
-        json=$(cat services.json)
-        services=$(echo "$json" | jq -r '.services[] | @base64')
-
-        echo "Clean up the previous content under 'Service introduction'"
-        sed -i '/# Service introduction/,$ {/# Service introduction/!d}' README.md
-
-        for service in $services; do
-          _jq() {
-            echo ${service} | base64 --decode | jq -r ${1}
-          }
-          folder=$(_jq '.service_folder_name')
-          url=$(_jq '.service_url')
-          youtube_url=$(_jq '.service_youtube_url')
-          service_name=$(_jq '.service_name')
-
-          if [ ! -d "$folder" ]; then
-            mkdir "$folder"
-            echo "Folder created: $folder"
-          else
-            echo "Folder already exists: $folder"
-          fi
-
-          echo "# $service_name" > "$folder/README.md"
-          # Update the service README.md content
-          echo -e "- Official AWS URL: $url" >> "$folder/README.md"
-          echo -e "- Official YouTube Introduction: $youtube_url" >> "$folder/README.md"
-          echo "Check the new content in $folder/README.md"
-          cat "$folder/README.md"
-
-          # Update the README.md content
-          echo -e "- [$folder/README.md](./$folder/README.md)" >> README.md
-        done
-        echo "Check the new content in README.md"
-        cat README.md
+      run: sh generate-content.sh
 
     - name: Commit changes
       run: |

--- a/generate-content.sh
+++ b/generate-content.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+json=$(cat services.json)
+services=$(echo "$json" | jq -r '.services[] | @base64')
+
+echo "Clean up the previous content under 'Service introduction'"
+sed -i '/# Service introduction/,$ {/# Service introduction/!d}' README.md
+
+for service in $services; do
+  _jq() {
+    echo ${service} | base64 --decode | jq -r ${1}
+  }
+  folder=$(_jq '.service_folder_name')
+  url=$(_jq '.service_url')
+  youtube_url=$(_jq '.service_youtube_url')
+  service_name=$(_jq '.service_name')
+
+  if [ ! -d "$folder" ]; then
+    mkdir "$folder"
+    echo "Folder created: $folder"
+  else
+    echo "Folder already exists: $folder"
+  fi
+
+  echo "# $service_name" > "$folder/README.md"
+  # Update the service README.md content
+  echo -e "- Official AWS URL: $url" >> "$folder/README.md"
+  echo -e "- Official YouTube Introduction: $youtube_url" >> "$folder/README.md"
+  echo "Check the new content in $folder/README.md"
+  cat "$folder/README.md"
+
+  # Update the README.md content
+  echo -e "- [$folder/README.md](./$folder/README.md)" >> README.md
+done
+echo "Check the new content in README.md"
+cat README.md


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #94 line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #94
<!-- Be noted that $94 is the issue ID -->

## What is the purpose of the change
This pull request enhances the documentation by:

- ✨ Moving the 'Generate Content' steps from the GitHub action to a separate shell script. ✨
- 📝 Updating the '.github/workflows/generate-content.yml' file to call the new shell script. 📝

These changes improve the maintainability and organization of the code, making it easier to manage and update the documentation generation process.
## Summary of Changes

- Created a new shell script `generate-content.sh` to handle content generation.
- Modified the GitHub Actions workflow to execute the `generate-content.sh` script.
- Committed and pushed the changes to the repository.

With these changes, the documentation generation process is now more streamlined and easier to maintain. 🚀
<!-- Add a description of the overall background and high level changes that this PR introduces -->

*(E.g.: This pull request improves documentation of area A by adding ....)*
